### PR TITLE
pool(docs): Minor typo fix

### DIFF
--- a/pages/overview/pool.mdx
+++ b/pages/overview/pool.mdx
@@ -5,7 +5,7 @@ import Image from 'next/image'
 
 # Pool
 
-Allo distributes funds in pools, where each fund is owned by an profile in the
+Allo distributes funds in pools, where each fund is owned by a profile in the
 [registry](/overview/project-registry) and has an [allocation
 strategy](/overview/allocation-strategy) that determines how the funds are
 distributed.


### PR DESCRIPTION
Changed "an project" to "a project".